### PR TITLE
Future events

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -47,6 +47,8 @@ plugins:
   - jekyll-seo-tag
   - jekyll-remote-theme
 
+future: true
+
 defaults:
   - scope:
       path: ""

--- a/docs/_tec-events/2024-04-18-privacy-pie.md
+++ b/docs/_tec-events/2024-04-18-privacy-pie.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-03-18
+date: 2024-04-18
 title: "Privacy PIE"
 image: assets/images/events/2024-04-18-privacy-pie/1712286140650.png
 ---

--- a/docs/_tec-events/2024-04-25-right-to-repair-workshop.md
+++ b/docs/_tec-events/2024-04-25-right-to-repair-workshop.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-03-25
+date: 2024-04-25
 title: "Right to Repair Workshop"
 image: assets/images/events/2024-02-27-right-to-repair-workshop/RightToRepairHub2.jpg
 ---

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -25,20 +25,24 @@ This publication will examine issues in tech and society in a way that (hopefull
 <h2>TEC Articles</h2>
 <div class="articles-list">
     {% for post in site.posts %}
-    <div class="article-item">
-        <h2 class="article-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
-        {%- if post.image -%}
-        <div class="article-image">
-            <img src="{{ post.image }}" alt="Article image">
+        {% assign today_date = 'now' | date: "%s" %}
+        {% assign post_date = post.date | date: "%s" %}
+        {% if  today_date > post_date %}
+        <div class="article-item">
+            <h2 class="article-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            {%- if post.image -%}
+            <div class="article-image">
+                <img src="{{ post.image }}" alt="Article image">
+            </div>
+            {%- endif -%}
+            <div class="article-info">
+                <p class="author">{{ post.author | join: ', ' }}</p>
+                <p class="date">{{ post.date | date: "%b %-d, %Y" }}</p>
+                <p class="reading-time">{{ post.reading_time }} min read</p>
+                <p class="excerpt">{{ post.excerpt }}</p>
+            </div>
         </div>
-        {%- endif -%}
-        <div class="article-info">
-            <p class="author">{{ post.author | join: ', ' }}</p>
-            <p class="date">{{ post.date | date: "%b %-d, %Y" }}</p>
-            <p class="reading-time">{{ post.reading_time }} min read</p>
-            <p class="excerpt">{{ post.excerpt }}</p>
-        </div>
-    </div>
+        {% endif %}
     {% endfor %}
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,29 +1,50 @@
----
-title: Tech Education Collaborative
-layout: home
+--- 
+title: Tech Education Collaborative 
+layout: home 
 ---
 
 <b>The Technology Education Collaborative supports the secure, thoughtful use of technology.</b>
 <p>
-Our efforts help people better understand the computers embedded in everyday life so people are empowered to make intentional decisions about the tech they use.
+    Our efforts help people better understand the computers embedded in everyday life so people are empowered to make intentional decisions about the tech they use.
+</p>
 <p>
-Through articles written by experienced technologists and credible sources, we explore topics ranging from cybersecurity to cutting-edge tech advancements. We keep people impacted by tech policy – which is basically everyone – informed by sharing actionable information about current legislation and policy work in the tech space.
+    Through articles written by experienced technologists and credible sources, we explore topics ranging from cybersecurity to cutting-edge tech advancements. We keep people impacted by tech policy – which is basically everyone – informed by sharing actionable
+    information about current legislation and policy work in the tech space.
+</p>
 <p>
     By providing both physical and virtual spaces for technology meetups and events, <strong>we support and foster the Arizona tech community</strong> with accessible ways to promote thoughtful, robust discussion and collaboration.
-
+</p>
 <h1>Upcoming Events</h1>
-<a href="tec-events/2024-04-18-privacy-pie.html">Privacy PIE, April 18th
-    <img src="/assets/images/events/2024-04-18-privacy-pie/1712286140650.png" alt="Example setup of a workbench at the right to repair event">
-</a>
-<a href="tec-events/2024-04-25-right-to-repair-workshop.html">Right to Repair Workshop, April 25th
-    <img src="/assets/images/events/2024-02-27-right-to-repair-workshop/RightToRepairHub2.jpg" alt="Example setup of a workbench at the right to repair event">
-</a>
+<div class="events-list">
+    {% for event in site.tec-events %}
+        {% assign today_date = 'now' | date: "%s" %}
+        {% assign event_date = event.date | date: "%s" %}
+        {% if event_date > today_date %}
+        <div class="event-item">
+            <a href="{{ event.url }}">
+                <h2 class="event-title">{{ event.title }}</h2>
+                {%- if event.image -%}
+                <div class="event-image">
+                    <img src="{{ event.image }}" alt="Event image">
+                </div>
+                {%- endif -%}
+                <div class="event-info">
+                    <p class="date">{{ event.date | date: "%b %-d, %Y" }}</p>
+                </div>
+            </a>
+        </div>
+        {% endif %}
+    {% endfor %}
+</div>
 <p>
-<h1>Recent Publications</h1>
-<a href="https://techedcollab.substack.com/p/emerging-trends-in-cybersecurity">Emerging Trends in Cybersecurity</a>
+    <h1>Recent Publications</h1>
+    <a href="https://techedcollab.substack.com/p/emerging-trends-in-cybersecurity">Emerging Trends in Cybersecurity</a>
+</p>
 <p>
-<h1>Past Publications</h1>
-<a href="https://us21.campaign-archive.com/home/?u=fff4f557eb25c16e17141d89b&id=77c72f8e21">Check out our previous newsletters here</a>
+    <h1>Past Publications</h1>
+    <a href="https://us21.campaign-archive.com/home/?u=fff4f557eb25c16e17141d89b&id=77c72f8e21">Check out our previous newsletters here</a>
+</p>
 <p>
-<h1>Local Tech Events</h1>
-<a href="local-tech-calendar.html">Check out upcoming local tech events here</a>
+    <h1>Local Tech Events</h1>
+    <a href="local-tech-calendar.html">Check out upcoming local tech events here</a>
+</p>

--- a/docs/tec-events.md
+++ b/docs/tec-events.md
@@ -5,15 +5,17 @@ layout: page
 <div class="events-list">
     {% for event in site.tec-events reversed %}
     <div class="event-item">
-        <h2 class="event-title"><a href="{{ event.url }}">{{ event.title }}</a></h2>
-        {%- if event.image -%}
-        <div class="event-image">
-            <img src="{{ event.image }}" alt="Event image">
-        </div>
-        {%- endif -%}
-        <div class="event-info">
-            <p class="date">{{ event.date | date: "%b %-d, %Y" }}</p>
-        </div>
+        <a href="{{ event.url }}">
+            <h2 class="event-title">{{ event.title }}</h2>
+            {%- if event.image -%}
+            <div class="event-image">
+                <img src="{{ event.image }}" alt="Event image">
+            </div>
+            {%- endif -%}
+            <div class="event-info">
+                <p class="date">{{ event.date | date: "%b %-d, %Y" }}</p>
+            </div>
+        </a>
     </div>
     {% endfor %}
 </div>


### PR DESCRIPTION
This has the changes necessary for issue #17.

As Jekyll doesn't do future on a per collection basis (They have multiple issues on the topic but all went to stale), the entire site is set to create future posts so that the tec events collection can have future events. However that would then show future posts cause again per site not per collection, so updated that to filter out future posts at site build time. 

With that any post that is set to the future will not show up until the site is rebuilt, or redeployed, after the date of its post. How far after the date, no idea. It might be seconds or it could be a full date change. 