### PR TITLE
change cname from www.techedcollab.org to old.techedcollab.org due to…

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-www.techedcollab.org
+old.techedcollab.org


### PR DESCRIPTION
… ghost migration